### PR TITLE
Adding wrappers for hipsolverDnCreate and hipsolverDnSetStream

### DIFF
--- a/src/util.cpp
+++ b/src/util.cpp
@@ -63,3 +63,19 @@ hipsolverStatus_t hipsolverSetStream(hipsolverHandle_t handle,
   }
   return (handle != nullptr) ? HIPSOLVER_STATUS_SUCCESS : HIPSOLVER_STATUS_HANDLE_IS_NULLPTR;
 }
+
+// helpers
+hipsolverStatus_t hipsolverDnCreate(hipsolverHandle_t* handle)
+{
+    return hipsolverCreate(handle);
+}
+
+hipsolverStatus_t hipsolverDnDestroy(hipsolverHandle_t handle)
+{
+    return hipsolverDestroy(handle);
+}
+
+hipsolverStatus_t hipsolverDnSetStream(hipsolverHandle_t handle, hipStream_t streamId)
+{
+    return hipsolverSetStream(handle, streamId);
+}


### PR DESCRIPTION
This adds in wrappers for hipsolverDn* which just call hipsolver* etc. This is the same as in AMD: https://github.com/ROCm/hipSOLVER/blob/c35541f64d3f791883fcde69d55ce805c31c8927/library/src/common/hipsolver_dense_common.cpp#L35. 