### PR TITLE
ci: build chipStar + H4I-MKLShim from source in presubmit

### DIFF
--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -20,6 +20,54 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 1
+      - name: Build chipStar + H4I-MKLShim from source
+        shell: bash
+        run: |
+          set -e
+          if [ -f "$HOME/.local/init/bash" ]; then
+            export MODULESHOME=$HOME/.local
+            source "$MODULESHOME/init/bash"
+          elif [ -f /etc/profile.d/lmod.sh ]; then
+            source /etc/profile.d/lmod.sh
+          else
+            source /etc/profile.d/modules.sh
+          fi
+          module use /space/pvelesko/modulefiles
+          module load oneapi/2025.0.4 llvm/22.0-native level-zero/dgpu
+          module list
+
+          # Build chipStar and H4I-MKLShim from source into a job-local prefix
+          # instead of relying on the system module installs. Everything is
+          # built, installed, and consumed within this job, so the install is
+          # self-consistent (no external staging paths to go stale).
+          DEPS="$PWD/deps"
+          SRC="$RUNNER_TEMP/dep-src"
+          rm -rf "$DEPS" "$SRC"
+          mkdir -p "$SRC"
+
+          # chipStar: library only (no tests, no samples) -- builds fast.
+          git clone --depth 1 --recurse-submodules --shallow-submodules \
+            https://github.com/CHIP-SPV/chipStar "$SRC/chipStar"
+          cmake -S "$SRC/chipStar" -B "$SRC/chipStar/build" -G Ninja \
+            -DLLVM_CONFIG_BIN="$(which llvm-config)" \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCHIP_BUILD_TESTS=OFF \
+            -DCHIP_BUILD_SAMPLES=OFF \
+            -DCMAKE_INSTALL_PREFIX="$DEPS/chipstar"
+          ninja -C "$SRC/chipStar/build"
+          cmake --install "$SRC/chipStar/build"
+
+          # H4I-MKLShim: built with icpx.
+          git clone --depth 1 https://github.com/CHIP-SPV/H4I-MKLShim "$SRC/H4I-MKLShim"
+          cmake -S "$SRC/H4I-MKLShim" -B "$SRC/H4I-MKLShim/build" \
+            -DCMAKE_CXX_COMPILER="$(which icpx)" \
+            -DINTEL_COMPILER_PATH="$(which icpx)" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_PREFIX="$DEPS/mklshim" \
+            -DCMAKE_POLICY_VERSION_MINIMUM=3.5
+          cmake --build "$SRC/H4I-MKLShim/build" -j 8 --target install
+
+          echo "DEPS=$DEPS" >> "$GITHUB_ENV"
       - name: Build
         shell: bash
         run: |
@@ -33,11 +81,12 @@ jobs:
             source /etc/profile.d/modules.sh
           fi
           module use /space/pvelesko/modulefiles
-          module load oneapi/2025.0.4 llvm/22.0-native HIP/chipStar/main level-zero/dgpu HIP/H4I-MKLShim/oneapi-2025.0.4
-          module list
+          module load oneapi/2025.0.4 llvm/22.0-native level-zero/dgpu
+          export CMAKE_PREFIX_PATH="$DEPS/chipstar:$DEPS/mklshim:${CMAKE_PREFIX_PATH:-}"
+          export LD_LIBRARY_PATH="$DEPS/chipstar/lib:$DEPS/mklshim/lib:${LD_LIBRARY_PATH:-}"
           rm -rf build
           cmake -S . -B build \
-            -DCMAKE_CXX_COMPILER="$(which hipcc)" \
+            -DCMAKE_CXX_COMPILER="$DEPS/chipstar/bin/hipcc" \
             -DCLANG_COMPILER_PATH="$(which clang++)" \
             -DCMAKE_BUILD_TYPE=Release \
             -DCMAKE_INSTALL_PREFIX=$PWD/build/install \

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -85,6 +85,8 @@ jobs:
           module load oneapi/2025.0.4 llvm/22.0-native level-zero/dgpu
           export CMAKE_PREFIX_PATH="$DEPS/chipstar:$DEPS/mklshim:${CMAKE_PREFIX_PATH:-}"
           export LD_LIBRARY_PATH="$DEPS/chipstar/lib:$DEPS/mklshim/lib:${LD_LIBRARY_PATH:-}"
+          export LIBRARY_PATH="$DEPS/chipstar/lib:$DEPS/mklshim/lib:${LIBRARY_PATH:-}"
+          export CPATH="$DEPS/chipstar/include:$DEPS/mklshim/include:${CPATH:-}"
           rm -rf build
           cmake -S . -B build \
             -DCMAKE_CXX_COMPILER="$DEPS/chipstar/bin/hipcc" \

--- a/.github/workflows/presubmit.yml
+++ b/.github/workflows/presubmit.yml
@@ -63,6 +63,7 @@ jobs:
             -DCMAKE_CXX_COMPILER="$(which icpx)" \
             -DINTEL_COMPILER_PATH="$(which icpx)" \
             -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_PREFIX_PATH="$DEPS/chipstar" \
             -DCMAKE_INSTALL_PREFIX="$DEPS/mklshim" \
             -DCMAKE_POLICY_VERSION_MINIMUM=3.5
           cmake --build "$SRC/H4I-MKLShim/build" -j 8 --target install


### PR DESCRIPTION
Stop depending on the system module installs (`HIP/chipStar/main`, `HIP/H4I-MKLShim`). A broken system chipStar install (staging paths baked in, then `/tmp` cleaned) took down all H4I CI; building deps from source per-job removes that coupling.

The presubmit now builds chipStar (library only — `CHIP_BUILD_TESTS=OFF -DCHIP_BUILD_SAMPLES=OFF`, fast `ninja`) and H4I-MKLShim into a job-local prefix, then builds this library against them. Deps are built, installed, and consumed within the same job, so the install is self-consistent (no external staging paths to go stale).